### PR TITLE
Fixing emscripten build

### DIFF
--- a/3rdparty/nvtt/nvcore/nvcore.h
+++ b/3rdparty/nvtt/nvcore/nvcore.h
@@ -139,6 +139,8 @@
 #   define NV_CPU_ARM 1
 #elif defined POSH_CPU_AARCH64
 #   define NV_CPU_AARCH64 1
+#elif defined POSH_CPU_EMSCRIPTEN
+#   define NV_CPU_EMSCRIPTEN 1
 #else
 #   error "Unsupported CPU"
 #endif
@@ -162,6 +164,10 @@
 #ifndef NV_CPU_AARCH64
 #	define NV_CPU_AARCH64 0
 #endif // NV_CPU_AARCH64
+
+#ifndef NV_CPU_EMSCRIPTEN
+#	define NV_CPU_EMSCRIPTEN 0
+#endif // NV_CPU_EMSCRIPTEN
 
 // Compiler:
 

--- a/3rdparty/nvtt/nvcore/posh.h
+++ b/3rdparty/nvtt/nvcore/posh.h
@@ -296,7 +296,7 @@ LLVM:
 ** Determine target operating system
 ** ----------------------------------------------------------------------------
 */
-#if defined linux || defined __linux__
+#if defined linux || defined __linux__ || defined EMSCRIPTEN
 #  define POSH_OS_LINUX 1 
 #  define POSH_OS_STRING "Linux"
 #endif
@@ -536,6 +536,11 @@ LLVM:
 #  define POSH_CPU_STRING "PA-RISC"
 #endif
 
+#if defined EMSCRIPTEN
+#  define POSH_CPU_EMSCRIPTEN 1
+#  define POSH_CPU_STRING "EMSCRIPTEN"
+#endif
+
 #if !defined POSH_CPU_STRING
 #  error POSH cannot determine target CPU
 #  define POSH_CPU_STRING "Unknown" /* this is here for Doxygen's benefit */
@@ -673,7 +678,7 @@ LLVM:
 ** the MIPS series, so we have to be careful about those.
 ** ----------------------------------------------------------------------------
 */
-#if defined POSH_CPU_X86 || defined POSH_CPU_AXP || defined POSH_CPU_STRONGARM || defined POSH_CPU_AARCH64 || defined POSH_OS_WIN32 || defined POSH_OS_WINCE || defined __MIPSEL__
+#if defined POSH_CPU_X86 || defined POSH_CPU_AXP || defined POSH_CPU_STRONGARM || defined POSH_CPU_AARCH64 || defined POSH_OS_WIN32 || defined POSH_OS_WINCE || defined __MIPSEL__ || defined POSH_CPU_EMSCRIPTEN
 #  define POSH_ENDIAN_STRING "little"
 #  define POSH_LITTLE_ENDIAN 1
 #else


### PR DESCRIPTION
If you try to compile bgfx+bx+bimg right now you will most likely get this:

```
zoh.cpp
In file included from ../../../../bimg/3rdparty/nvtt/bc6h/zoh.cpp:15:
In file included from ../../../../bimg/3rdparty/nvtt/bc6h/tile.h:15:
In file included from ../../../../bimg/3rdparty/nvtt/bc6h/zoh_utils.h:17:
In file included from ../../../../bimg/3rdparty/nvtt\nvmath/vector.h:6:
In file included from ../../../../bimg/3rdparty/nvtt\nvmath/nvmath.h:9:
In file included from ../../../../bimg/3rdparty/nvtt\nvcore/utils.h:6:
In file included from ../../../../bimg/3rdparty/nvtt\nvcore/debug.h:6:
In file included from ../../../../bimg/3rdparty/nvtt\nvcore/nvcore.h:24:
../../../../bimg/3rdparty/nvtt\nvcore/posh.h:540:4: error: POSH cannot determine target CPU
#  error POSH cannot determine target CPU
   ^
In file included from ../../../../bimg/3rdparty/nvtt/bc6h/zoh.cpp:15:
In file included from ../../../../bimg/3rdparty/nvtt/bc6h/tile.h:15:
In file included from ../../../../bimg/3rdparty/nvtt/bc6h/zoh_utils.h:17:
In file included from ../../../../bimg/3rdparty/nvtt\nvmath/vector.h:6:
In file included from ../../../../bimg/3rdparty/nvtt\nvmath/nvmath.h:9:
In file included from ../../../../bimg/3rdparty/nvtt\nvcore/utils.h:6:
In file included from ../../../../bimg/3rdparty/nvtt\nvcore/debug.h:6:
../../../../bimg/3rdparty/nvtt\nvcore/nvcore.h:143:5: error: "Unsupported CPU"
#   error "Unsupported CPU"
    ^
../../../../bimg/3rdparty/nvtt\nvcore/nvcore.h:359:9: error: "GCC: Platform not supported"
#       error "GCC: Platform not supported"
        ^
In file included from ../../../../bimg/3rdparty/nvtt/bc6h/zoh.cpp:15:
In file included from ../../../../bimg/3rdparty/nvtt/bc6h/tile.h:15:
In file included from ../../../../bimg/3rdparty/nvtt/bc6h/zoh_utils.h:17:
In file included from ../../../../bimg/3rdparty/nvtt\nvmath/vector.h:6:
In file included from ../../../../bimg/3rdparty/nvtt\nvmath/nvmath.h:9:
In file included from ../../../../bimg/3rdparty/nvtt\nvcore/utils.h:6:
../../../../bimg/3rdparty/nvtt\nvcore/debug.h:163:17: error: variable has incomplete type 'void'
NVCORE_API void NV_CDECL nvDebugPrint( const char *msg, ... ) __attribute__((format (printf, 1, 2)));
```

So I fixed it but not 100% sure if this is the best fix to do, but looks like it does the trick.