### PR TITLE
Fixes compilation when bimg is compiled as amalgamated

### DIFF
--- a/src/bimg_p.h
+++ b/src/bimg_p.h
@@ -3,6 +3,8 @@
  * License: https://github.com/bkaradzic/bimg#license-bsd-2-clause
  */
 
+#pragma once
+
 #include <bimg/bimg.h>
 #include <bx/allocator.h>
 #include <bx/readerwriter.h>


### PR DESCRIPTION
The headers is included twice and redefines strucs and macros and fails to compile... added a tiny pragma once to avoid this.