### PR TITLE
ATC and ASTC texture format support

### DIFF
--- a/tools/texturec/texturec.cpp
+++ b/tools/texturec/texturec.cpp
@@ -879,7 +879,7 @@ int main(int _argc, const char* _argv[])
 		}
 		else if (options.format != bimg::TextureFormat::RGBA8)
 		{
-			help("Ouput PNG format must be RGBA8.");
+			help("Output PNG format must be RGBA8.");
 			return bx::kExitFailure;
 		}
 	}
@@ -891,7 +891,7 @@ int main(int _argc, const char* _argv[])
 		}
 		else if (options.format != bimg::TextureFormat::RGBA16F)
 		{
-			help("Ouput EXR format must be RGBA16F.");
+			help("Output EXR format must be RGBA16F.");
 			return bx::kExitFailure;
 		}
 	}
@@ -958,6 +958,12 @@ int main(int _argc, const char* _argv[])
 			}
 			else if (NULL != bx::strFindI(saveAs, "png") )
 			{
+				if (output->m_format != bimg::TextureFormat::RGBA8)
+				{
+					help("Incompatible output texture format. Output PNG format must be RGBA8.", err);
+					return bx::kExitFailure;
+				}
+
 				bimg::ImageMip mip;
 				bimg::imageGetRawData(*output, 0, 0, output->m_data, output->m_size, mip);
 				bimg::imageWritePng(&writer

--- a/tools/texturec/texturec.cpp
+++ b/tools/texturec/texturec.cpp
@@ -26,7 +26,7 @@
 #include <string>
 
 #define BIMG_TEXTUREC_VERSION_MAJOR 1
-#define BIMG_TEXTUREC_VERSION_MINOR 13
+#define BIMG_TEXTUREC_VERSION_MINOR 14
 
 struct Options
 {


### PR DESCRIPTION
This adds support for ATI's ATC/ATCE/ATCI still used by some mobile devices, and the most commonly used six of the ASTC formats. (I only needed 5x5 and 8x5 for the Football Manager Android SKUs, but I decided to also add the potentially useful ones referenced by https://developer.nvidia.com/astc-texture-compression-for-game-assets while recapitulating that work, as a compromise between that and the full range, which would dwarf all the other formats.)

Because ASTC has non-power-of-two block sizes, I had to generalise some of the image code.

I have not added ATC or ASTC encoding yet. (I have my own tool for that.) I could add ASTC to texturec pretty easily if that is desired. For ATC I use a legacy closed-source library from the Adreno SDK, so some replacement would have to be found for that.

An upcoming pull request adds the corresponding support to bgfx.
