### PR TITLE
fix build for mingw/gcc

### DIFF
--- a/3rdparty/astc/astc_codec_internals.h
+++ b/3rdparty/astc/astc_codec_internals.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <math.h>
 #include "mathlib.h"
 
 #ifndef MIN


### PR DESCRIPTION
I can't build bimg on mingw/gcc, and the error message is:
```
In file included from C:/msys64/mingw64/include/c++/8.2.0/cmath:45,
                 from C:/msys64/mingw64/include/c++/8.2.0/math.h:36,
                 from ../../../3rdparty/astc/astc_color_quantize.cpp:20:
C:/msys64/mingw64/x86_64-w64-mingw32/include/math.h: In function 'int __isnanl(long double)':
C:/msys64/mingw64/x86_64-w64-mingw32/include/math.h:573:65: error: lvalue required as left operand of assignment
     xx = (int) (ld.ldt->lh.low | (ld.ldt->lh.high & 0x7fffffffu)); /* explicit */
                                                                 ^
```

I found astc lib define a macro xx to xx() at 
 https://github.com/bkaradzic/bimg/blob/master/3rdparty/astc/vectypes.h#L15874  , and mingw's runtime use xx as a local variable name in math.h .

```C
  __CRT_INLINE int __cdecl __isnanl (long double _x)
  {
#if defined(__x86_64__) || defined(_AMD64_)
    __mingw_fp_types_t ld;
    int xx, signexp;

    ld.ld = &_x;
    signexp = (ld.ldt->lh.sign_exponent & 0x7fff) << 1;
    xx = (int) (ld.ldt->lh.low | (ld.ldt->lh.high & 0x7fffffffu)); /* explicit */
    signexp |= (unsigned int) (xx | (-xx)) >> 31;
    signexp = 0xfffe - signexp;
    return (int) ((unsigned int) signexp) >> 16;
#elif defined(__arm__) || defined(_ARM_) || defined(__aarch64__) || defined(_ARM64_)
    return __isnan(_x);
#elif defined(__i386__) || defined(_X86_)
    unsigned short sw;
    __asm__ __volatile__ ("fxam;"
      "fstsw %%ax": "=a" (sw) : "t" (_x));
    return (sw & (FP_NAN | FP_NORMAL | FP_INFINITE | FP_ZERO | FP_SUBNORMAL))
      == FP_NAN;
#endif
  }
```

Including math.h before vectypes.h can solve this issue.