### PR TITLE
Fix aarch64 build

### DIFF
--- a/3rdparty/nvtt/nvcore/debug.h
+++ b/3rdparty/nvtt/nvcore/debug.h
@@ -165,7 +165,7 @@ NVCORE_API void NV_CDECL nvDebugPrint( const char *msg, ... ) __attribute__((for
 namespace nv
 {
     inline bool isValidPtr(const void * ptr) {
-    #if NV_CPU_X86_64
+    #if NV_CPU_X86_64 || NV_CPU_AARCH64
         if (ptr == NULL) return true;
         if (reinterpret_cast<uint64>(ptr) < 0x10000ULL) return false;
         if (reinterpret_cast<uint64>(ptr) >= 0x000007FFFFFEFFFFULL) return false;


### PR DESCRIPTION
clang doesn't allow to compile the code due to `cast from pointer to smaller type uint32` error. Use 64bit code path for NV_CPU_AARCH64 as well as NV_CPU_X86_64.