### PR TITLE
DDS loader crash fix

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -4861,8 +4861,9 @@ namespace bimg
 				{
 					BX_CHECK(offset <= _size, "Reading past size of data buffer! (offset %d, size %d)", offset, _size);
 
-					width  = bx::max<uint32_t>(blockWidth  * minBlockX, ( (width  + blockWidth  - 1) / blockWidth )*blockWidth);
-					height = bx::max<uint32_t>(blockHeight * minBlockY, ( (height + blockHeight - 1) / blockHeight)*blockHeight);
+					uint32_t mipwidth = bx::max<uint32_t>(blockWidth  * minBlockX, ( (width  + blockWidth  - 1) / blockWidth )*blockWidth);
+					uint32_t mipheight = bx::max<uint32_t>(blockHeight * minBlockY, ( (height + blockHeight - 1) / blockHeight)*blockHeight);
+
 					depth  = bx::max<uint32_t>(1, depth);
 
 					uint32_t mipSize = width/blockWidth * height/blockHeight * depth * blockSize;
@@ -4870,8 +4871,8 @@ namespace bimg
 					if (side == _side
 					&&  lod  == _lod)
 					{
-						_mip.m_width     = width;
-						_mip.m_height    = height;
+						_mip.m_width     = mipwidth;
+						_mip.m_height    = mipheight;
 						_mip.m_depth     = depth;
 						_mip.m_blockSize = blockSize;
 						_mip.m_size      = mipSize;


### PR DESCRIPTION
Fix for crash when loading a dds file of 3136x3104 with full mip-chain. The calculation to calculate the mip size was different from what two separate dds compressors seem to be using.

Repro case: create a DDS texture of the given resolution, and create a full mip chain for it. Try to load it, and during loading the application will crash because it is reading memory it shouldn't. I used 
both TheCompressonator and Paint.NET to export the DDS, both failed to load.