### PR TITLE
fix build for mingw/gcc (macro xx conflict)

### DIFF
--- a/3rdparty/astc/astc_codec_internals.h
+++ b/3rdparty/astc/astc_codec_internals.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <math.h>
 #include "mathlib.h"
 
 #ifndef MIN


### PR DESCRIPTION
It's the same issue with #17 . @andrewwillmott I guess it would be better if you merge this patch into your repo.