### PR TITLE
imageDecodeToRgba32f use src (rather than dst) width and height

### DIFF
--- a/tools/texturec/texturec.cpp
+++ b/tools/texturec/texturec.cpp
@@ -411,9 +411,9 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 					bimg::imageDecodeToRgba32f(_allocator
 						, rgba
 						, mip.m_data
-						, dstMip.m_width
-						, dstMip.m_height
-						, dstMip.m_depth
+						, mip.m_width
+						, mip.m_height
+						, mip.m_depth
 						, dstMip.m_width*16
 						, mip.m_format
 						);
@@ -522,7 +522,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 						, mip.m_width
 						, mip.m_height
 						, mip.m_depth
-						, mip.m_width*16
+						, dstMip.m_width*16
 						, mip.m_format
 						);
 


### PR DESCRIPTION
The texturec cause a segmentation fault today when I compress a 1024x1024 normal map texture into ASTC6x6 format.

The reason is ASTC6x6 format use 6x6 unit, so the the target image is 1026x1026. It's bigger than the source 1024x1024.

`bimg::imageDecodeToRgba32f` should use the width of source rather than the dst.

