### PR TITLE
Include stdlib.h for Android

### DIFF
--- a/3rdparty/astc-codec/src/base/string_utils.h
+++ b/3rdparty/astc-codec/src/base/string_utils.h
@@ -17,6 +17,7 @@
 
 #include <limits>
 #include <string>
+#include <stdlib.h>
 
 namespace astc_codec {
 namespace base {


### PR DESCRIPTION
Android needs this for `strtol`