### PR TITLE
Enable KTX sRGB formats

### DIFF
--- a/include/bimg/bimg.h
+++ b/include/bimg/bimg.h
@@ -541,6 +541,7 @@ namespace bimg
 		, uint32_t _depth
 		, uint8_t _numMips
 		, uint32_t _numLayers
+		, bool _srgb
 		, const void* _src
 		, bx::Error* _err = NULL
 		);

--- a/tools/texturec/texturec.cpp
+++ b/tools/texturec/texturec.cpp
@@ -931,7 +931,7 @@ void help(const char* _error = NULL, bool _showHelp = true)
 		  "  -q <quality>             Encoding quality (default, fastest, highest).\n"
 		  "  -m, --mips               Generate mip-maps.\n"
 		  "      --mipskip <N>        Skip <N> number of mips.\n"
-		  "  -n, --normalmap          Input texture is normal map.\n"
+		  "  -n, --normalmap          Input texture is normal map. (Implies --linear)\n"
 		  "      --equirect           Input texture is equirectangular projection of cubemap.\n"
 		  "      --strip              Input texture is horizontal strip of cubemap.\n"
 		  "      --sdf                Compute SDF texture.\n"
@@ -940,7 +940,7 @@ void help(const char* _error = NULL, bool _showHelp = true)
 		  "      --pma                Premultiply alpha into RGB channel.\n"
 		  "      --linear             Input and output texture is linear color space (gamma correction won't be applied).\n"
 		  "      --max <max size>     Maximum width/height (image will be scaled down and\n"
-		  "                           aspect ratio will be preserved.\n"
+		  "                           aspect ratio will be preserved)\n"
 		  "      --radiance <model>   Radiance cubemap filter. (Lighting model: Phong, PhongBrdf, Blinn, BlinnBrdf, GGX)\n"
 		  "      --as <extension>     Save as.\n"
 		  "      --formats            List all supported formats.\n"
@@ -1091,6 +1091,12 @@ int main(int _argc, const char* _argv[])
 		return bx::kExitFailure;
 	}
 
+	// Normal maps are always linear
+	if (options.normalMap)
+	{
+		options.linear = true;
+	}
+
 	const char* maxSize = cmdLine.findOption("max");
 	if (NULL != maxSize)
 	{
@@ -1215,6 +1221,8 @@ int main(int _argc, const char* _argv[])
 
 	if (NULL != output)
 	{
+		output->m_srgb = !options.linear;
+
 		bx::FileWriter writer;
 		if (bx::open(&writer, outputFileName, false, &err) )
 		{


### PR DESCRIPTION
All the `m_internalFmtSrgb` values were there already, just not used.

I've done this as 2 commits in case you just wanted to merge the first. The second commit makes texturec write sRGB by default, which might be a bit drastic (maybe an --srgb flag would be preferable?)