### PR TITLE
Fix bug where loading uncompressed sRGB KTX files would swap B/R

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -4011,8 +4011,9 @@ namespace bimg
 				break;
 			}
 
-			if (s_translateKtxFormat[ii].m_internalFmtSrgb == glInternalFormat)
-			{
+			if (s_translateKtxFormat[ii].m_internalFmtSrgb == glInternalFormat
+			&&  s_translateKtxFormat[ii].m_fmt == glBaseInternalFormat)
+                        {
 				format = TextureFormat::Enum(ii);
 				srgb = true;
 				break;


### PR DESCRIPTION
KTX_SRGB8_ALPHA8 files would load in as BGRA. Fix by matching on both format and base format. 

Caused by these two formats having the same m_internalFormatSrgb but different m_fmt:
```		
{ KTX_BGRA,                                     KTX_SRGB8_ALPHA8,                               KTX_BGRA,                                     KTX_UNSIGNED_BYTE,                }, // BGRA8
{ KTX_RGBA8,                                    KTX_SRGB8_ALPHA8,                               KTX_RGBA,                                     KTX_UNSIGNED_BYTE,                }, // RGBA8
```