### PR TITLE
Fix emscripten builds by correcting `ctype.h` include.

### DIFF
--- a/src/image_decode.cpp
+++ b/src/image_decode.cpp
@@ -17,7 +17,7 @@ BX_PRAGMA_DIAGNOSTIC_IGNORED_MSVC(4100) // error C4100: '' : unreferenced formal
 BX_PRAGMA_DIAGNOSTIC_IGNORED_MSVC(4389) // warning C4389 : '==' : signed / unsigned mismatch
 BX_PRAGMA_DIAGNOSTIC_IGNORED_MSVC(4505) // warning C4505: 'tinyexr::miniz::def_realloc_func': unreferenced local function has been removed
 #if BX_PLATFORM_EMSCRIPTEN
-#	include <compat/ctype.h>
+#	include <ctype.h>
 #endif // BX_PLATFORM_EMSCRIPTEN
 #define MINIZ_NO_ARCHIVE_APIS
 #define MINIZ_NO_STDIO


### PR DESCRIPTION
The emscripten compat headers work by transparently augmenting imports and including the original headers via `#include_next`.
The search path for emscripten places `system/include/compat` before `system/include`, and so importing with `compat/ctype.h` causes the preprocessor to skip over `system/include/compat` and land the search cursor on `system/include`, which then causes the subsequent `#include_next <ctype.h>` lookup to fail while processing the compat header.

Fixes emscripten-core/emscripten#13109.
Fixes bkaradzic/bgfx#2336.