### PR TITLE
fix mingw build, See #27

### DIFF
--- a/3rdparty/astc/astc_codec_internals.h
+++ b/3rdparty/astc/astc_codec_internals.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <math.h>
 #include "mathlib.h"
 
 #ifndef MIN


### PR DESCRIPTION
Can't build in mingw after updating astc lib. https://github.com/bkaradzic/bimg/commit/200165a0dd8517e32bc9a315e3f8e656ebd7d362

See https://github.com/bkaradzic/bimg/pull/27

@andrewwillmott