### PR TITLE
Fix compilation with gcc8/9

### DIFF
--- a/3rdparty/astc/vectypes.h
+++ b/3rdparty/astc/vectypes.h
@@ -16,9 +16,12 @@
 #include <string.h>
 #include <stdint.h>
 
+#ifndef __USE_MISC
 typedef uint32_t uint;
 typedef uint16_t ushort;
 typedef uint64_t ulong;
+#endif
+
 typedef uint8_t uchar;
 typedef int8_t schar;
 


### PR DESCRIPTION
Under Gcc9 (Ubuntu 20 WSL) and Gcc8 (Debian 10), bimg will fail to compile due to sys/types.h already defining "uint", "ushort" and "ulong" types.

This commit skips the definition of this three types in vectypes.h if __USE_MISC is defined. (compatibility with old C names)