### PR TITLE
Fixes for cubemap loading from ktx/pvr3 container

### DIFF
--- a/include/bimg/bimg.h
+++ b/include/bimg/bimg.h
@@ -195,6 +195,7 @@ namespace bimg
 		bool     m_cubeMap;
 		bool     m_ktx;
 		bool     m_ktxLE;
+		bool     m_pvr3;
 		bool     m_srgb;
 	};
 


### PR DESCRIPTION
ktx: imageSize checking is modified to conform to cubemap exception rule.
https://www.khronos.org/registry/KTX/specs/1.0/ktxspec_v1.html#2.16

This fired the assert: BX_ASSERT(size == imageSize, "KTX: Image size mismatch %d (expected %d).", size, imageSize);
(To reproduce with texturev I had to enable assert because it was defined as NOOP in debug msvc project)

pvr3: container surface layout is similar to ktx (mip first then array/cubemap faces)

See section 4 in http://cdn.imgtec.com/sdk-documentation/PVR+File+Format.Specification.pdf

Here are two files (ktx and a pvr) that reproduce the issue:
[cubemaps.zip](https://github.com/bkaradzic/bimg/files/6943735/cubemaps.zip)
