### PR TITLE
Fix misc. typo

### DIFF
--- a/src/image_cubemap_filter.cpp
+++ b/src/image_cubemap_filter.cpp
@@ -896,7 +896,7 @@ namespace bimg
 
 		if (0.0f < totalWeight)
 		{
-			// Optimized Reversible Tonemapper for Resovle
+			// Optimized Reversible Tonemapper for Resolve
 			// https://web.archive.org/web/20180717182019/https://gpuopen.com/optimized-reversible-tonemapper-for-resolve/
 			// Average, then reverse the tonemapper
 			//


### PR DESCRIPTION
Found via `codespell -q 3 -S ./3rdparty -L ba,inout,lod,quater,treshold`