### PR TITLE
Prevent the export of stb functions

### DIFF
--- a/src/image_decode.cpp
+++ b/src/image_decode.cpp
@@ -67,6 +67,7 @@ BX_PRAGMA_DIAGNOSTIC_IGNORED_GCC("-Wimplicit-fallthrough");
 #define STBI_REALLOC(_ptr, _size) lodepng_realloc(_ptr, _size)
 #define STBI_FREE(_ptr)           lodepng_free(_ptr)
 #define STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_STATIC
 #include <stb/stb_image.h>
 BX_PRAGMA_DIAGNOSTIC_POP();
 


### PR DESCRIPTION
I encountered linking issues when the executable was using other libraries that also utilized stb