### PR TITLE
Fix ktx parsing failing if texture array has 6 layers

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -5210,7 +5210,7 @@ namespace bimg
 
 				if (_imageContainer.m_ktx)
 				{
-					const uint32_t size = _imageContainer.m_cubeMap ? mipSize : mipSize * numSides;
+					const uint32_t size = _imageContainer.m_numLayers == 1 && _imageContainer.m_cubeMap ? mipSize : mipSize * numSides;
 					uint32_t imageSize  = bx::toHostEndian(*(const uint32_t*)&data[offset], _imageContainer.m_ktxLE);
 					BX_ASSERT(size == imageSize, "KTX: Image size mismatch %d (expected %d).", size, imageSize);
 					BX_UNUSED(size, imageSize);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -5210,7 +5210,7 @@ namespace bimg
 
 				if (_imageContainer.m_ktx)
 				{
-					const uint32_t size = numSides == 6 ? mipSize : mipSize * numSides;
+					const uint32_t size = _imageContainer.m_cubeMap ? mipSize : mipSize * numSides;
 					uint32_t imageSize  = bx::toHostEndian(*(const uint32_t*)&data[offset], _imageContainer.m_ktxLE);
 					BX_ASSERT(size == imageSize, "KTX: Image size mismatch %d (expected %d).", size, imageSize);
 					BX_UNUSED(size, imageSize);


### PR DESCRIPTION
Fixing line in code that assumes if numSides == 6 then it must be a cubemap even though numSides in this situation can refer to numLayers as well. 

		const uint16_t numSides = _imageContainer.m_numLayers * (_imageContainer.m_cubeMap ? 6 : 1);


I caught this when trying to load a 6-layer texture array. I tested the other changes in https://github.com/bkaradzic/bimg/commit/82781e44d8844e13c60a65f7425abd7eea91e428 and didn't catch any other issues with the code.

I confirmed code works with 09-hdr and my skybox code still.