### PR TITLE
Fix Emscripten wasm64 compilation error .

### DIFF
--- a/3rdparty/nvtt/nvcore/debug.h
+++ b/3rdparty/nvtt/nvcore/debug.h
@@ -166,7 +166,7 @@ NVCORE_API void NV_CDECL nvDebugPrint( const char *msg, ... ) __attribute__((for
 namespace nv
 {
     inline bool isValidPtr(const void * ptr) {
-    #if NV_CPU_X86_64 || NV_CPU_AARCH64
+    #if NV_CPU_X86_64 || NV_CPU_AARCH64 || defined(__wasm64__)
         if (ptr == NULL) return true;
         if (reinterpret_cast<uint64>(ptr) < 0x10000ULL) return false;
         if (reinterpret_cast<uint64>(ptr) >= 0x000007FFFFFEFFFFULL) return false;


### PR DESCRIPTION
Fixes the following compile error:

```
bimg/3rdparty/nvtt/nvcore/debug.h:177:10: error: cast from pointer to
smaller type 'uint32' (aka 'unsigned int') loses information
```