### PR TITLE
fix exr memory allocation size overflow by turning the size into a uint64_t

### DIFF
--- a/src/image_decode.cpp
+++ b/src/image_decode.cpp
@@ -547,7 +547,7 @@ namespace bimg
 						stepA  = 1;
 					}
 
-					data   = (uint8_t*)bx::alloc(_allocator, exrImage.width * exrImage.height * dstBpp/8);
+					data   = (uint8_t*)bx::alloc(_allocator, (size_t)exrImage.width * exrImage.height * dstBpp/8);
 					width  = exrImage.width;
 					height = exrImage.height;
 


### PR DESCRIPTION
On large enough textures, the byte size can overflow a regular int. In my case, the image was 8320x8320 and the dstBpp was 128. 
During evaluation, the size eventually overflows just as it multiplies by dstBpp before dividing by 8.

8320x8320x128 -> 8,860,467,200, while an int32_t can only reach 2,147,483,647 and an uint32_t can reach 4,294,967,295.

Please let me know if you'd prefer an alternative solution!