### PR TITLE
Remove sizeof from nvNoAssert

### DIFF
--- a/3rdparty/nvtt/nvcore/debug.h
+++ b/3rdparty/nvtt/nvcore/debug.h
@@ -17,7 +17,7 @@
 
 #define nvNoAssert(exp) \
     NV_MULTI_LINE_MACRO_BEGIN \
-    (void)sizeof(exp); \
+    (void)(false && (exp)); \
     NV_MULTI_LINE_MACRO_END
 
 #if NV_NO_ASSERT


### PR DESCRIPTION
Some static code analysis tools might mistakenly consider this a misusage of sizeof(). Changing this to a boolean expression should keep the compiler time check and will be fine for static analysis. 