### PR TITLE
Added optional ASTC alpha weighting.

### DIFF
--- a/include/bimg/encode.h
+++ b/include/bimg/encode.h
@@ -26,6 +26,11 @@ namespace bimg
 		};
 	};
 
+	struct EncodeOptions
+	{
+		bool alphaWeight = false;
+	};
+
 	///
 	void imageEncodeFromRgba8(
 		  bx::AllocatorI* _allocator
@@ -37,6 +42,7 @@ namespace bimg
 		, TextureFormat::Enum _format
 		, Quality::Enum _quality
 		, bx::Error* _err = NULL
+		, const EncodeOptions* _options = NULL
 		);
 
 	///
@@ -50,6 +56,7 @@ namespace bimg
 		, TextureFormat::Enum _format
 		, Quality::Enum _quality
 		, bx::Error* _err = NULL
+		, const EncodeOptions* _options = NULL
 		);
 
 	///
@@ -64,6 +71,7 @@ namespace bimg
 		, TextureFormat::Enum _dstFormat
 		, Quality::Enum _quality
 		, bx::Error* _err
+		, const EncodeOptions* _options = NULL
 		);
 
 	///
@@ -72,6 +80,7 @@ namespace bimg
 		, TextureFormat::Enum _dstFormat
 		, Quality::Enum _quality
 		, const ImageContainer& _input
+		, const EncodeOptions* _options = NULL
 		);
 
 	///

--- a/src/image_encode.cpp
+++ b/src/image_encode.cpp
@@ -54,7 +54,7 @@ namespace bimg
 	};
 	static_assert(Quality::Count == BX_COUNTOF(s_astcQuality) );
 
-	void imageEncodeFromRgba8(bx::AllocatorI* _allocator, void* _dst, const void* _src, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _format, Quality::Enum _quality, bx::Error* _err)
+	void imageEncodeFromRgba8(bx::AllocatorI* _allocator, void* _dst, const void* _src, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _format, Quality::Enum _quality, bx::Error* _err, const EncodeOptions* _options)
 	{
 		const uint8_t* src = (const uint8_t*)_src;
 		uint8_t* dst = (uint8_t*)_dst;
@@ -157,6 +157,7 @@ namespace bimg
 			case TextureFormat::ASTC12x12:
 				{
 					const bimg::ImageBlockInfo& astcBlockInfo = bimg::getBlockInfo(_format);
+					const bool alphaWeight = NULL != _options && _options->alphaWeight;
 
 					astcenc_config config{};
 
@@ -165,6 +166,10 @@ namespace bimg
 					if (Quality::NormalMapDefault <= _quality)
 					{
 						astcFlags |= ASTCENC_FLG_MAP_NORMAL;
+					}
+					else if (alphaWeight)
+					{
+						astcFlags |= ASTCENC_FLG_USE_ALPHA_WEIGHT;
 					}
 
 					astcenc_error status = astcenc_config_init(
@@ -182,6 +187,11 @@ namespace bimg
 						BX_TRACE("astc error in config init %s", astcenc_get_error_string(status) );
 						BX_ERROR_SET(_err, BIMG_ERROR, "Unable to initialize astc config!");
 						break;
+					}
+
+					if (alphaWeight)
+					{
+						config.a_scale_radius = 1;
 					}
 
 					astcenc_context* context;
@@ -260,7 +270,7 @@ namespace bimg
 		}
 	}
 
-	void imageEncodeFromRgba32f(bx::AllocatorI* _allocator, void* _dst, const void* _src, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _dstFormat, Quality::Enum _quality, bx::Error* _err)
+	void imageEncodeFromRgba32f(bx::AllocatorI* _allocator, void* _dst, const void* _src, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _dstFormat, Quality::Enum _quality, bx::Error* _err, const EncodeOptions* _options)
 	{
 		BX_ERROR_SCOPE(_err);
 
@@ -303,7 +313,7 @@ namespace bimg
 						}
 					}
 
-					imageEncodeFromRgba8(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err);
+					imageEncodeFromRgba8(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err, _options);
 				}
 				else
 				{
@@ -316,7 +326,7 @@ namespace bimg
 		}
 	}
 
-	void imageEncode(bx::AllocatorI* _allocator, void* _dst, const void* _src, TextureFormat::Enum _srcFormat, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _dstFormat, Quality::Enum _quality, bx::Error* _err)
+	void imageEncode(bx::AllocatorI* _allocator, void* _dst, const void* _src, TextureFormat::Enum _srcFormat, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _dstFormat, Quality::Enum _quality, bx::Error* _err, const EncodeOptions* _options)
 	{
 		switch (_dstFormat)
 		{
@@ -346,7 +356,7 @@ namespace bimg
 				{
 					uint8_t* temp = (uint8_t*)bx::alloc(_allocator, _width*_height*_depth*4);
 					imageDecodeToRgba8(_allocator, temp, _src, _width, _height, _width*4, _srcFormat);
-					imageEncodeFromRgba8(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err);
+					imageEncodeFromRgba8(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err, _options);
 					bx::free(_allocator, temp);
 				}
 				break;
@@ -356,7 +366,7 @@ namespace bimg
 				{
 					uint8_t* temp = (uint8_t*)bx::alloc(_allocator, _width*_height*_depth*16);
 					imageDecodeToRgba32f(_allocator, temp, _src, _width, _height, _depth, _width*16, _srcFormat);
-					imageEncodeFromRgba32f(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err);
+					imageEncodeFromRgba32f(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err, _options);
 					bx::free(_allocator, temp);
 				}
 				break;
@@ -370,7 +380,7 @@ namespace bimg
 		}
 	}
 
-	ImageContainer* imageEncode(bx::AllocatorI* _allocator, TextureFormat::Enum _dstFormat, Quality::Enum _quality, const ImageContainer& _input)
+	ImageContainer* imageEncode(bx::AllocatorI* _allocator, TextureFormat::Enum _dstFormat, Quality::Enum _quality, const ImageContainer& _input, const EncodeOptions* _options)
 	{
 		ImageContainer* output = imageAlloc(_allocator
 			, _dstFormat
@@ -408,6 +418,7 @@ namespace bimg
 						, _dstFormat
 						, _quality
 						, &err
+						, _options
 						);
 				}
 			}

--- a/tools/texturec/texturec.cpp
+++ b/tools/texturec/texturec.cpp
@@ -46,6 +46,7 @@ struct Options
 			"\t equirect: %s\n"
 			"\t    strip: %s\n"
 			"\t   linear: %s\n"
+			"\talphaWeight: %s\n"
 			, maxSize
 			, mipSkip
 			, edge
@@ -59,6 +60,7 @@ struct Options
 			, equirect  ? "true" : "false"
 			, strip     ? "true" : "false"
 			, linear    ? "true" : "false"
+			, alphaWeight ? "true" : "false"
 			);
 	}
 
@@ -77,6 +79,7 @@ struct Options
 	bool sdf       = false;
 	bool alphaTest = false;
 	bool linear    = false;
+	bool alphaWeight = false;
 };
 
 void imageRgba32fNormalize(void* _dst, uint32_t _width, uint32_t _height, uint32_t _srcPitch, const void* _src)
@@ -140,6 +143,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 
 	if (NULL != input)
 	{
+		const bimg::EncodeOptions encodeOptions = { _options.alphaWeight };
 		bimg::TextureFormat::Enum inputFormat  = input->m_format;
 		bimg::TextureFormat::Enum outputFormat = input->m_format;
 
@@ -305,7 +309,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 			if (inputFormat != outputFormat
 			&&  bimg::isCompressed(outputFormat) )
 			{
-				output = bimg::imageEncode(_allocator, outputFormat, _options.quality, *input);
+				output = bimg::imageEncode(_allocator, outputFormat, _options.quality, *input, &encodeOptions);
 			}
 			else
 			{
@@ -355,7 +359,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 
 			if (bimg::TextureFormat::RGBA32F != outputFormat)
 			{
-				bimg::ImageContainer* temp = bimg::imageEncode(_allocator, outputFormat, _options.quality, *output);
+				bimg::ImageContainer* temp = bimg::imageEncode(_allocator, outputFormat, _options.quality, *output, &encodeOptions);
 				bimg::imageFree(output);
 
 				output = temp;
@@ -461,6 +465,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 						, outputFormat
 						, nmapQuality
 						, _err
+						, &encodeOptions
 						);
 
 					for (uint8_t lod = 1; lod < numMips && _err->isOk(); ++lod)
@@ -496,6 +501,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 							, outputFormat
 							, nmapQuality
 							, _err
+							, &encodeOptions
 							);
 					}
 
@@ -553,6 +559,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 						, outputFormat
 						, _options.quality
 						, _err
+						, &encodeOptions
 						);
 
 					if (1 < numMips
@@ -610,6 +617,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 								, outputFormat
 								, _options.quality
 								, _err
+								, &encodeOptions
 								);
 						}
 					}
@@ -728,6 +736,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 								, bimg::TextureFormat::A8
 								, _options.quality
 								, _err
+								, &encodeOptions
 							);
 						}
 
@@ -803,6 +812,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 						, outputFormat
 						, _options.quality
 						, _err
+						, &encodeOptions
 						);
 
 					for (uint8_t lod = 1; lod < numMips && _err->isOk(); ++lod)
@@ -852,6 +862,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 							, outputFormat
 							, _options.quality
 							, _err
+							, &encodeOptions
 							);
 					}
 
@@ -953,6 +964,7 @@ void help(const char* _error = NULL, bool _showHelp = true)
 		  "      --iqa                Image Quality Assessment\n"
 		  "      --pma                Premultiply alpha into RGB channel.\n"
 		  "      --linear             Input and output texture is linear color space (gamma correction won't be applied).\n"
+		  "      --alpha-weight <0|1>  Enable alpha weighting.\n"
 		  "      --max <max size>     Maximum width/height (image will be scaled down and\n"
 		  "                           aspect ratio will be preserved)\n"
 		  "      --radiance <model>   Radiance cubemap filter. (Lighting model: Phong, PhongBrdf, Blinn, BlinnBrdf, GGX)\n"
@@ -1097,6 +1109,19 @@ int main(int _argc, const char* _argv[])
 	options.iqa       = cmdLine.hasArg("iqa");
 	options.pma       = cmdLine.hasArg("pma");
 	options.linear    = cmdLine.hasArg("linear");
+
+	const char* alphaWeight = cmdLine.findOption("alpha-weight");
+	if (NULL != alphaWeight)
+	{
+		uint32_t alphaWeightValue = 0;
+		if (!bx::fromString(&alphaWeightValue, alphaWeight) )
+		{
+			help("Parsing `--alpha-weight` failed.");
+			return bx::kExitFailure;
+		}
+
+		options.alphaWeight = alphaWeightValue != 0;
+	}
 
 	if (options.equirect
 	&&  options.strip)


### PR DESCRIPTION
Added optional ASTC alpha weighting.

  - add EncodeOptions::alphaWeight
  - add texturec --alpha-weight <0|1>
  - enable ASTCENC_FLG_USE_ALPHA_WEIGHT
  - set a_scale_radius = 1 when enabled

This adds optional ASTC alpha weighting for textures where the alpha channel represents transparency.

In `astcenc`, `ASTCENC_FLG_USE_ALPHA_WEIGHT` adjusts the encoder's error metric so RGB error matters less in more
transparent regions, allowing for quality gain elsewhere. This is useful for assets such as cutouts, foliage, sprites, decals, and UI, where preserving RGB behind transparent texels is less important. This is also relevant for textures that have gone through alpha dilation.

For linearly filtered textures, this patch also sets `a_scale_radius = 1`, following the recommendation in `astcenc.h`, to
help reduce color bleed from transparent texels adjacent to non-transparent texels.

This is kept opt-in because it is appropriate for transparency-bearing textures, but should not change default behavior
for opaque content or for textures where alpha is data rather than opacity.