### PR TITLE
Add ASTC encode swizzle support.

### DIFF
--- a/include/bimg/encode.h
+++ b/include/bimg/encode.h
@@ -26,6 +26,32 @@ namespace bimg
 		};
 	};
 
+	struct AstcSwizzle
+	{
+		enum Enum
+		{
+			R,
+			G,
+			B,
+			A,
+			Zero,
+			One,
+
+			Count
+		};
+	};
+
+	struct EncodeOptions
+	{
+		AstcSwizzle::Enum astcSwizzle[4] =
+		{
+			AstcSwizzle::R,
+			AstcSwizzle::G,
+			AstcSwizzle::B,
+			AstcSwizzle::A,
+		};
+	};
+
 	///
 	void imageEncodeFromRgba8(
 		  bx::AllocatorI* _allocator
@@ -37,6 +63,7 @@ namespace bimg
 		, TextureFormat::Enum _format
 		, Quality::Enum _quality
 		, bx::Error* _err = NULL
+		, const EncodeOptions* _options = NULL
 		);
 
 	///
@@ -50,6 +77,7 @@ namespace bimg
 		, TextureFormat::Enum _format
 		, Quality::Enum _quality
 		, bx::Error* _err = NULL
+		, const EncodeOptions* _options = NULL
 		);
 
 	///
@@ -64,6 +92,7 @@ namespace bimg
 		, TextureFormat::Enum _dstFormat
 		, Quality::Enum _quality
 		, bx::Error* _err
+		, const EncodeOptions* _options = NULL
 		);
 
 	///
@@ -72,6 +101,7 @@ namespace bimg
 		, TextureFormat::Enum _dstFormat
 		, Quality::Enum _quality
 		, const ImageContainer& _input
+		, const EncodeOptions* _options = NULL
 		);
 
 	///

--- a/src/image_encode.cpp
+++ b/src/image_encode.cpp
@@ -54,7 +54,21 @@ namespace bimg
 	};
 	static_assert(Quality::Count == BX_COUNTOF(s_astcQuality) );
 
-	void imageEncodeFromRgba8(bx::AllocatorI* _allocator, void* _dst, const void* _src, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _format, Quality::Enum _quality, bx::Error* _err)
+	static astcenc_swz getAstcencSwizzle(AstcSwizzle::Enum _swizzle, astcenc_swz _default)
+	{
+		switch (_swizzle)
+		{
+		case AstcSwizzle::R:    return ASTCENC_SWZ_R;
+		case AstcSwizzle::G:    return ASTCENC_SWZ_G;
+		case AstcSwizzle::B:    return ASTCENC_SWZ_B;
+		case AstcSwizzle::A:    return ASTCENC_SWZ_A;
+		case AstcSwizzle::Zero: return ASTCENC_SWZ_0;
+		case AstcSwizzle::One:  return ASTCENC_SWZ_1;
+		default:                return _default;
+		}
+	}
+
+	void imageEncodeFromRgba8(bx::AllocatorI* _allocator, void* _dst, const void* _src, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _format, Quality::Enum _quality, bx::Error* _err, const EncodeOptions* _options)
 	{
 		const uint8_t* src = (const uint8_t*)_src;
 		uint8_t* dst = (uint8_t*)_dst;
@@ -219,12 +233,12 @@ namespace bimg
 					}
 					else
 					{
-						static const astcenc_swizzle swizzle
-						{  //0123/rgba swizzle corresponds to ASTC_RGBA
-							ASTCENC_SWZ_R,
-							ASTCENC_SWZ_G,
-							ASTCENC_SWZ_B,
-							ASTCENC_SWZ_A,
+						astcenc_swizzle swizzle
+						{
+							getAstcencSwizzle(NULL != _options ? _options->astcSwizzle[0] : AstcSwizzle::R, ASTCENC_SWZ_R),
+							getAstcencSwizzle(NULL != _options ? _options->astcSwizzle[1] : AstcSwizzle::G, ASTCENC_SWZ_G),
+							getAstcencSwizzle(NULL != _options ? _options->astcSwizzle[2] : AstcSwizzle::B, ASTCENC_SWZ_B),
+							getAstcencSwizzle(NULL != _options ? _options->astcSwizzle[3] : AstcSwizzle::A, ASTCENC_SWZ_A),
 						};
 
 						status = astcenc_compress_image(context, &image, &swizzle, dst, compLen, 0);
@@ -260,7 +274,7 @@ namespace bimg
 		}
 	}
 
-	void imageEncodeFromRgba32f(bx::AllocatorI* _allocator, void* _dst, const void* _src, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _dstFormat, Quality::Enum _quality, bx::Error* _err)
+	void imageEncodeFromRgba32f(bx::AllocatorI* _allocator, void* _dst, const void* _src, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _dstFormat, Quality::Enum _quality, bx::Error* _err, const EncodeOptions* _options)
 	{
 		BX_ERROR_SCOPE(_err);
 
@@ -303,7 +317,7 @@ namespace bimg
 						}
 					}
 
-					imageEncodeFromRgba8(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err);
+					imageEncodeFromRgba8(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err, _options);
 				}
 				else
 				{
@@ -316,7 +330,7 @@ namespace bimg
 		}
 	}
 
-	void imageEncode(bx::AllocatorI* _allocator, void* _dst, const void* _src, TextureFormat::Enum _srcFormat, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _dstFormat, Quality::Enum _quality, bx::Error* _err)
+	void imageEncode(bx::AllocatorI* _allocator, void* _dst, const void* _src, TextureFormat::Enum _srcFormat, uint32_t _width, uint32_t _height, uint32_t _depth, TextureFormat::Enum _dstFormat, Quality::Enum _quality, bx::Error* _err, const EncodeOptions* _options)
 	{
 		switch (_dstFormat)
 		{
@@ -346,7 +360,7 @@ namespace bimg
 				{
 					uint8_t* temp = (uint8_t*)bx::alloc(_allocator, _width*_height*_depth*4);
 					imageDecodeToRgba8(_allocator, temp, _src, _width, _height, _width*4, _srcFormat);
-					imageEncodeFromRgba8(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err);
+					imageEncodeFromRgba8(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err, _options);
 					bx::free(_allocator, temp);
 				}
 				break;
@@ -356,7 +370,7 @@ namespace bimg
 				{
 					uint8_t* temp = (uint8_t*)bx::alloc(_allocator, _width*_height*_depth*16);
 					imageDecodeToRgba32f(_allocator, temp, _src, _width, _height, _depth, _width*16, _srcFormat);
-					imageEncodeFromRgba32f(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err);
+					imageEncodeFromRgba32f(_allocator, _dst, temp, _width, _height, _depth, _dstFormat, _quality, _err, _options);
 					bx::free(_allocator, temp);
 				}
 				break;
@@ -370,7 +384,7 @@ namespace bimg
 		}
 	}
 
-	ImageContainer* imageEncode(bx::AllocatorI* _allocator, TextureFormat::Enum _dstFormat, Quality::Enum _quality, const ImageContainer& _input)
+	ImageContainer* imageEncode(bx::AllocatorI* _allocator, TextureFormat::Enum _dstFormat, Quality::Enum _quality, const ImageContainer& _input, const EncodeOptions* _options)
 	{
 		ImageContainer* output = imageAlloc(_allocator
 			, _dstFormat
@@ -408,6 +422,7 @@ namespace bimg
 						, _dstFormat
 						, _quality
 						, &err
+						, _options
 						);
 				}
 			}

--- a/tools/texturec/texturec.cpp
+++ b/tools/texturec/texturec.cpp
@@ -46,6 +46,7 @@ struct Options
 			"\t equirect: %s\n"
 			"\t    strip: %s\n"
 			"\t   linear: %s\n"
+			"\tastcSwizzle: %d%d%d%d\n"
 			, maxSize
 			, mipSkip
 			, edge
@@ -59,6 +60,10 @@ struct Options
 			, equirect  ? "true" : "false"
 			, strip     ? "true" : "false"
 			, linear    ? "true" : "false"
+			, astcSwizzle[0]
+			, astcSwizzle[1]
+			, astcSwizzle[2]
+			, astcSwizzle[3]
 			);
 	}
 
@@ -77,7 +82,67 @@ struct Options
 	bool sdf       = false;
 	bool alphaTest = false;
 	bool linear    = false;
+	bimg::AstcSwizzle::Enum astcSwizzle[4] =
+	{
+		bimg::AstcSwizzle::R,
+		bimg::AstcSwizzle::G,
+		bimg::AstcSwizzle::B,
+		bimg::AstcSwizzle::A,
+	};
 };
+
+static bool isAstcFormat(bimg::TextureFormat::Enum _format)
+{
+	switch (_format)
+	{
+	case bimg::TextureFormat::ASTC4x4:
+	case bimg::TextureFormat::ASTC5x4:
+	case bimg::TextureFormat::ASTC5x5:
+	case bimg::TextureFormat::ASTC6x5:
+	case bimg::TextureFormat::ASTC6x6:
+	case bimg::TextureFormat::ASTC8x5:
+	case bimg::TextureFormat::ASTC8x6:
+	case bimg::TextureFormat::ASTC8x8:
+	case bimg::TextureFormat::ASTC10x5:
+	case bimg::TextureFormat::ASTC10x6:
+	case bimg::TextureFormat::ASTC10x8:
+	case bimg::TextureFormat::ASTC10x10:
+	case bimg::TextureFormat::ASTC12x10:
+	case bimg::TextureFormat::ASTC12x12:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static bool parseAstcSwizzle(bimg::AstcSwizzle::Enum* _dst, const char* _swizzle)
+{
+	if (NULL == _swizzle
+	||  '\0' == _swizzle[0]
+	||  '\0' == _swizzle[1]
+	||  '\0' == _swizzle[2]
+	||  '\0' == _swizzle[3]
+	||  '\0' != _swizzle[4])
+	{
+		return false;
+	}
+
+	for (uint32_t ii = 0; ii < 4; ++ii)
+	{
+		switch (bx::toLower(_swizzle[ii]))
+		{
+		case 'r': _dst[ii] = bimg::AstcSwizzle::R;    break;
+		case 'g': _dst[ii] = bimg::AstcSwizzle::G;    break;
+		case 'b': _dst[ii] = bimg::AstcSwizzle::B;    break;
+		case 'a': _dst[ii] = bimg::AstcSwizzle::A;    break;
+		case '0': _dst[ii] = bimg::AstcSwizzle::Zero; break;
+		case '1': _dst[ii] = bimg::AstcSwizzle::One;  break;
+		default:  return false;
+		}
+	}
+
+	return true;
+}
 
 void imageRgba32fNormalize(void* _dst, uint32_t _width, uint32_t _height, uint32_t _srcPitch, const void* _src)
 {
@@ -140,6 +205,11 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 
 	if (NULL != input)
 	{
+		bimg::EncodeOptions encodeOptions;
+		encodeOptions.astcSwizzle[0] = _options.astcSwizzle[0];
+		encodeOptions.astcSwizzle[1] = _options.astcSwizzle[1];
+		encodeOptions.astcSwizzle[2] = _options.astcSwizzle[2];
+		encodeOptions.astcSwizzle[3] = _options.astcSwizzle[3];
 		bimg::TextureFormat::Enum inputFormat  = input->m_format;
 		bimg::TextureFormat::Enum outputFormat = input->m_format;
 
@@ -305,7 +375,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 			if (inputFormat != outputFormat
 			&&  bimg::isCompressed(outputFormat) )
 			{
-				output = bimg::imageEncode(_allocator, outputFormat, _options.quality, *input);
+				output = bimg::imageEncode(_allocator, outputFormat, _options.quality, *input, &encodeOptions);
 			}
 			else
 			{
@@ -355,7 +425,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 
 			if (bimg::TextureFormat::RGBA32F != outputFormat)
 			{
-				bimg::ImageContainer* temp = bimg::imageEncode(_allocator, outputFormat, _options.quality, *output);
+				bimg::ImageContainer* temp = bimg::imageEncode(_allocator, outputFormat, _options.quality, *output, &encodeOptions);
 				bimg::imageFree(output);
 
 				output = temp;
@@ -461,6 +531,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 						, outputFormat
 						, nmapQuality
 						, _err
+						, &encodeOptions
 						);
 
 					for (uint8_t lod = 1; lod < numMips && _err->isOk(); ++lod)
@@ -496,6 +567,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 							, outputFormat
 							, nmapQuality
 							, _err
+							, &encodeOptions
 							);
 					}
 
@@ -553,6 +625,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 						, outputFormat
 						, _options.quality
 						, _err
+						, &encodeOptions
 						);
 
 					if (1 < numMips
@@ -610,6 +683,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 								, outputFormat
 								, _options.quality
 								, _err
+								, &encodeOptions
 								);
 						}
 					}
@@ -728,6 +802,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 								, bimg::TextureFormat::A8
 								, _options.quality
 								, _err
+								, &encodeOptions
 							);
 						}
 
@@ -803,6 +878,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 						, outputFormat
 						, _options.quality
 						, _err
+						, &encodeOptions
 						);
 
 					for (uint8_t lod = 1; lod < numMips && _err->isOk(); ++lod)
@@ -852,6 +928,7 @@ bimg::ImageContainer* convert(bx::AllocatorI* _allocator, const void* _inputData
 							, outputFormat
 							, _options.quality
 							, _err
+							, &encodeOptions
 							);
 					}
 
@@ -953,6 +1030,7 @@ void help(const char* _error = NULL, bool _showHelp = true)
 		  "      --iqa                Image Quality Assessment\n"
 		  "      --pma                Premultiply alpha into RGB channel.\n"
 		  "      --linear             Input and output texture is linear color space (gamma correction won't be applied).\n"
+		  "      --swizzle <rgba>      ASTC input channel swizzle. Four chars from R,G,B,A,0,1.\n"
 		  "      --max <max size>     Maximum width/height (image will be scaled down and\n"
 		  "                           aspect ratio will be preserved)\n"
 		  "      --radiance <model>   Radiance cubemap filter. (Lighting model: Phong, PhongBrdf, Blinn, BlinnBrdf, GGX)\n"
@@ -1097,6 +1175,28 @@ int main(int _argc, const char* _argv[])
 	options.iqa       = cmdLine.hasArg("iqa");
 	options.pma       = cmdLine.hasArg("pma");
 	options.linear    = cmdLine.hasArg("linear");
+
+	const char* astcSwizzle = cmdLine.findOption("swizzle");
+	if (NULL != astcSwizzle)
+	{
+		if (!isAstcFormat(options.format) )
+		{
+			help("`--swizzle` requires an explicit ASTC output format.");
+			return bx::kExitFailure;
+		}
+
+		if (options.normalMap)
+		{
+			help("`--swizzle` cannot be used with `--normalmap`; ASTC normal maps use RRRG.");
+			return bx::kExitFailure;
+		}
+
+		if (!parseAstcSwizzle(options.astcSwizzle, astcSwizzle) )
+		{
+			help("Parsing `--swizzle` failed. Use exactly four characters from R,G,B,A,0,1.");
+			return bx::kExitFailure;
+		}
+	}
 
 	if (options.equirect
 	&&  options.strip)


### PR DESCRIPTION
  ASTC compression is more efficient when the input channels are mapped to the coding layout that best matches the stored
  data. The `astcenc` docs recommend using coding swizzles for this, especially for 1- and 2-component data and format-
  mapping cases.

  This patch exposes that control in `bimg` and `texturec` so callers can choose a non-default ASTC coding swizzle when
  needed, while keeping `rgba` as the default. The normal-map path remains unchanged and `--swizzle` is rejected with
  `--normalmap`.