### PR TITLE
nvtt: posh.h — detect __EMSCRIPTEN__ alongside legacy EMSCRIPTEN

### DIFF
--- a/3rdparty/nvtt/nvcore/posh.h
+++ b/3rdparty/nvtt/nvcore/posh.h
@@ -298,8 +298,8 @@ LLVM:
 ** Determine target operating system
 ** ----------------------------------------------------------------------------
 */
-#if defined linux || defined __linux__ || defined EMSCRIPTEN
-#  define POSH_OS_LINUX 1 
+#if defined linux || defined __linux__ || defined EMSCRIPTEN || defined __EMSCRIPTEN__
+#  define POSH_OS_LINUX 1
 #  define POSH_OS_STRING "Linux"
 #endif
 
@@ -548,7 +548,7 @@ LLVM:
 #  define POSH_CPU_STRING "PA-RISC"
 #endif
 
-#if defined EMSCRIPTEN
+#if defined EMSCRIPTEN || defined __EMSCRIPTEN__
 #  define POSH_CPU_EMSCRIPTEN 1
 #  define POSH_CPU_STRING "EMSCRIPTEN"
 #endif


### PR DESCRIPTION
### Summary

Vendored nvtt's `posh.h` (under `3rdparty/nvtt/nvcore/posh.h`) keys its
OS-detection and CPU-detection blocks off the legacy `EMSCRIPTEN` macro
(no underscores). emsdk 5.0 stopped predefining that macro — only the
modern `__EMSCRIPTEN__` survives. As a result, building bimg under
emsdk ≥ 5.0 fails with two errors that look unrelated but share the
same root cause.

### Failure under emsdk 5.0+

**1. `restrict` keyword left bare in nvcore/utils.h**

When `EMSCRIPTEN` isn't defined, `posh.h:301` doesn't set
`POSH_OS_LINUX`, so `nvcore.h` doesn't set `NV_OS_LINUX`, so
`defsgnuclinux.h` is never included, so `#define restrict __restrict__`
never runs. `nvcore/utils.h` then ships bare `restrict` into clang:

```
nvcore/utils.h:227:46: error: expected ')'
  227 |     void construct_range(T * restrict ptr, uint new_size, uint old_size) {
      |                                              ^
```

**2. POSH cannot determine target CPU**

When `EMSCRIPTEN` isn't defined, `posh.h:551`'s CPU detection block
doesn't trigger either, hitting:

```
posh.h:557: error: POSH cannot determine target CPU
```

### Fix

Widen both detection blocks to also recognize `__EMSCRIPTEN__`. Two
lines changed; behavior unchanged on older emsdk that still defined
the legacy spelling.

```diff
@@ -301,1 +301,1 @@
-#if defined linux || defined __linux__ || defined EMSCRIPTEN
+#if defined linux || defined __linux__ || defined EMSCRIPTEN || defined __EMSCRIPTEN__

@@ -551,1 +551,1 @@
-#if defined EMSCRIPTEN
+#if defined EMSCRIPTEN || defined __EMSCRIPTEN__
```

### Why fix bimg instead of \"just update emsdk\"

A related macro-spelling change in bx (#397) was rejected with [the
guidance](https://github.com/bkaradzic/bx/pull/397#issuecomment-4551366284):

> Emscripen is retarded with their way of doing updates, so I'm not
> going to bridge anything... just update to latest.

That guidance is exactly why this PR is needed: the failure surfaces
*precisely when* downstream consumers update emsdk to latest (5.0+),
because latest emsdk is what drops the legacy `EMSCRIPTEN` spelling.
The fix isn't about bridging an old emsdk — it's about teaching
bimg's vendored nvtt copy to recognize the macro current emsdk does
predefine.

### Test

Verified locally on emsdk 5.0.7 / clang-23 against a vendored bimg
build inside bgfx.cmake. Pre-patch: both errors above. Post-patch:
clean build through bimg + bimg_encode.

🤖🤖🤖