### PR TITLE
nvtt: posh.h — switch EMSCRIPTEN macro to __EMSCRIPTEN__

### DIFF
--- a/3rdparty/nvtt/nvcore/posh.h
+++ b/3rdparty/nvtt/nvcore/posh.h
@@ -298,8 +298,8 @@ LLVM:
 ** Determine target operating system
 ** ----------------------------------------------------------------------------
 */
-#if defined linux || defined __linux__ || defined EMSCRIPTEN
-#  define POSH_OS_LINUX 1 
+#if defined linux || defined __linux__ || defined __EMSCRIPTEN__
+#  define POSH_OS_LINUX 1
 #  define POSH_OS_STRING "Linux"
 #endif
 
@@ -548,7 +548,7 @@ LLVM:
 #  define POSH_CPU_STRING "PA-RISC"
 #endif
 
-#if defined EMSCRIPTEN
+#if defined __EMSCRIPTEN__
 #  define POSH_CPU_EMSCRIPTEN 1
 #  define POSH_CPU_STRING "EMSCRIPTEN"
 #endif


### PR DESCRIPTION
Reopens #125 with the simpler patch [@bkaradzic suggested in #125](https://github.com/bkaradzic/bimg/pull/125#issuecomment-4566043760): drop the legacy `EMSCRIPTEN` spelling entirely and just check `__EMSCRIPTEN__`. (GitHub blocks reopening a PR after force-push, so this is a fresh one.)

## What

`3rdparty/nvtt/nvcore/posh.h` keys OS+CPU detection off `EMSCRIPTEN`. emsdk ≥ 5.0 stopped predefining that macro — only `__EMSCRIPTEN__` survives ([emscripten-core/emscripten#21899](https://github.com/emscripten-core/emscripten/pull/21899)).

Without this patch, posh falls through to "unknown OS", `defsgnuclinux.h` is never included, `#define restrict __restrict__` never runs, and `nvcore/utils.h` ships bare `restrict` into clang which rejects it (`error: expected ')'`). The CPU detection then also fails with `#error POSH cannot determine target CPU`.

## Change

Two lines in `3rdparty/nvtt/nvcore/posh.h`:

```diff
-#if defined linux || defined __linux__ || defined EMSCRIPTEN
+#if defined linux || defined __linux__ || defined __EMSCRIPTEN__
 #  define POSH_OS_LINUX 1
```

```diff
-#if defined EMSCRIPTEN
+#if defined __EMSCRIPTEN__
 #  define POSH_CPU_EMSCRIPTEN 1
```

## Verified

Built `bgfx` + `bimg` + `bx` cleanly under emsdk 5.0.7 with the patched fork.