### PR TITLE
PNG: decode 8-bit grayscale (+alpha) to correct RGBA

### DIFF
--- a/src/image_decode.cpp
+++ b/src/image_decode.cpp
@@ -319,6 +319,13 @@ namespace bimg
 					dstFormat = bimg::TextureFormat::RGBA16;
 					copyData  = NULL;
 				}
+				else if (8 == state.info_raw.bitdepth
+				&& (LCT_GREY       == state.info_raw.colortype
+				||  LCT_GREY_ALPHA == state.info_raw.colortype) )
+				{
+					dstFormat = bimg::TextureFormat::RGBA8;
+					copyData  = NULL;
+				}
 
 				output = imageAlloc(_allocator
 					, dstFormat
@@ -442,6 +449,23 @@ namespace bimg
 						dst[1] = src[1];
 						dst[2] = src[2];
 						dst[3] = UINT16_MAX;
+					}
+				}
+				else if (8 == state.info_raw.bitdepth
+				&& (LCT_GREY       == state.info_raw.colortype
+				||  LCT_GREY_ALPHA == state.info_raw.colortype) )
+				{
+					// Grayscale (+alpha) has no dedicated GPU format; expand
+					// luminance across RGB and keep alpha so RGBA consumers get
+					// the right image instead of (L, A, 0, 255).
+					const bool     grayAlpha = LCT_GREY_ALPHA == state.info_raw.colortype;
+					const uint32_t srcBpp    = grayAlpha ? 2 : 1;
+					for (uint32_t ii = 0, num = width*height; ii < num; ++ii)
+					{
+						const uint8_t* src = (uint8_t*)data + ii*srcBpp;
+						      uint8_t* dst = (uint8_t*)output->m_data + ii*4;
+						dst[0] = dst[1] = dst[2] = src[0];
+						dst[3] = grayAlpha ? src[1] : UINT8_MAX;
 					}
 				}
 


### PR DESCRIPTION
### Problem

`imageParse(..., TextureFormat::RGBA8)` corrupts 8-bit grayscale and grayscale+alpha PNGs.

The LodePNG path decodes with `color_convert = 0`, so it keeps the native color type and maps:

- `LCT_GREY` -> `R8`
- `LCT_GREY_ALPHA` -> `RG8`

When the requested destination is `RGBA8`, `imageConvert` widens those via `bx::unpackRg8` / `bx::unpackR8`, which hardcode the missing channels:

```cpp
// bx pixelformat.inl
inline void unpackRg8(float* _dst, const void* _src) {
    _dst[0] = fromUnorm(src[0], 255.0f); // R
    _dst[1] = fromUnorm(src[1], 255.0f); // G
    _dst[2] = 0.0f;                      // B
    _dst[3] = 1.0f;                      // A -> opaque
}
```

So a grayscale+alpha source `(L, A)` comes out as **`(L, A, 0, 255)`**: the luminance is red-only, the real alpha ends up in green and the alpha channel is forced opaque. The image renders as an opaque box (typical for soft shadows / masks). 8-bit grayscale similarly becomes `(L, 0, 0, 255)`.

Observed decoded middle pixel of a `122x35` gray+alpha shadow: `RGBA = (20, 1, 0, 255)` — should be `(20, 20, 20, 1)`.

### Fix

Expand 8-bit `LCT_GREY` / `LCT_GREY_ALPHA` into `RGBA8` right after decode — luminance across RGB, alpha preserved (255 when absent) — mirroring the existing palette and 16-bit widening already done in `imageParseLodePng`. The native buffer is still read by the following `has_alpha` check, so that is unaffected.

16-bit grayscale (`R16` / `RG16`) has the same latent issue but is left out of this change to keep it minimal; happy to follow up if desired.